### PR TITLE
Re-use common I2C headers in ATMega code

### DIFF
--- a/mos/chips/atmega/atmega_2wire.h
+++ b/mos/chips/atmega/atmega_2wire.h
@@ -45,19 +45,8 @@
 #define CPU_HZ 1000000L
 #endif
 
-//! I2C acknowledge
-typedef enum {
-  I2C_NO_ACK = 0,
-  I2C_ACK    = 1,
-} i2cAck_t;
-
-//! I2C error
-typedef enum {
-  I2C_OK = 0,
-  I2C_ACK_ERROR = 1,
-  I2C_OTHER = 2,
-} i2cError_t;
-
+// I2C types
+#include <i2c_types.h>
 
 #ifndef TWI_SPEED
 #define TWI_SPEED 100000L


### PR DESCRIPTION
Simply included mos/include/i2c_types.h in atmega_2wire instead of re-declaring the required i2c types.